### PR TITLE
Add poetry as a dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,7 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -6,3 +10,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+zip_keys:
+- - c_stdlib_version
+  - cdt_name

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -22,13 +22,9 @@ requirements:
   run:
     - python >=3.8.0,<4.0.0
     - poetry-core >=1.7.0,<2.0.0
-  # poetry is actually a run dependency. But since that creates a dependency
-  # cycle, we add it only as a run_constrained for now (until fixed upstream).
-  # (N.B.: This means this package is unusable if `conda install`ed on its own.)
-  # refs:
-  #  - https://github.com/python-poetry/poetry/pull/5980
-  #  - https://github.com/conda-forge/poetry-feedstock/issues/70
-  run_constrained:
+    # warning: this is a circular dependency.  If this causes trouble (e.g.
+    # there is an update that simultaneously requires a new poetry and
+    # poetry-plugin-export, temporarly switch this to "run_constrained"
     - poetry >=1.8.0,<2.0.0
 
 # Skip tests partially due to dependency cycle (see above):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,11 +35,7 @@ test:
   commands:
     - test -f "${SP_DIR}"/poetry_plugin_export/__init__.py
     - "pip show poetry-plugin-export | grep -Fx 'Version: {{ version }}'"
-    # Ensure pip check has non-empty output and recognizes the missing dep.
-    - pip check | grep -F 'requires poetry, which is not installed.'
-    # Ensure pip check does not output anything else. (This includes
-    # "No broken requirements found." -- a signal to update the recipe ;)
-    - "! pip check | grep -Fv 'requires poetry, which is not installed.'"
+    - pip check
   requires:
     - pip
 


### PR DESCRIPTION
As long as the constraint isn't too tight, we should be able to handle the circular dependency between this package and poetry.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
